### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "ms-azuretools.vscode-azurefunctions",
-    "ms-vscode.csharp"
+    "ms-dotnettools.csharp"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To run this project, you will need the following Azure resources:
 
 Install [Visual Studio Code](https://code.visualstudio.com/) first and then add the following extensions:
 
-- [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) (only required for C# version of sample) - provides C# syntax checking, build and debug support
+- [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) (only required for C# version of sample) - provides C# syntax checking, build and debug support
 - [Azure IoT Tools](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-tools) - provides Azure IoT Edge development tooling
 
 > **Note**: Azure IoT Tools is an extension pack that installs 3 extensions that will show up in the Extensions pane in Visual Studio Code - *Azure IoT Hub Toolkit*, *Azure IoT Edge* and *Azure IoT Workbench*.

--- a/cloud/IoTHubListener/.vscode/extensions.json
+++ b/cloud/IoTHubListener/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
       "ms-azuretools.vscode-azurefunctions",
-      "ms-vscode.csharp"
+      "ms-dotnettools.csharp"
     ]
   }


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp", this means all extensions depending on it needs to be updated and i.e. all repositories with extension.json containing
```json
"recommendations": [
    "ms-vscode.csharp"
 ]
```
or you get errors like

![image](https://user-images.githubusercontent.com/1647294/76144809-2c18e500-6084-11ea-80ab-f365de742c99.png)