### PR TITLE
Added proper default value handling to GetTimeSpanEnvVar

### DIFF
--- a/edge/SimulatedEdgeDevice/modules/Watchdog/Program.cs
+++ b/edge/SimulatedEdgeDevice/modules/Watchdog/Program.cs
@@ -101,8 +101,11 @@ namespace HeartbeatModule
 
         public static TimeSpan GetTimeSpanEnvVar(string varName, double defaultValue){
             var strValue = Environment.GetEnvironmentVariable(varName);
-            var doubleValue = defaultValue; 
-            Double.TryParse(strValue, out doubleValue);
+            double doubleValue;
+            // If the parse fails, assign the default value
+            if(!Double.TryParse(strValue, out doubleValue)) {
+                doubleValue = defaultValue;
+            }
             return TimeSpan.FromSeconds(doubleValue);
         }
 


### PR DESCRIPTION
Default handling within the GetTimeSpanEnvVar wasn't falling through properly. 

Added more explicit code for default handling that directly checks the result of the TryParse and assigns based on the returned result.